### PR TITLE
Update 360tools_conv.c

### DIFF
--- a/app/360tools_conv/360tools_conv.c
+++ b/app/360tools_conv/360tools_conv.c
@@ -238,7 +238,7 @@ int main(int argc, const char * argv[])
 	}
 
 	if((cfmt == CONV_FMT_ERP_TO_CMP) &&
-        ((w_out%4 != 0 || h_out%4 != 0) || (w_out*3 != h_out*4)))
+        ((w_out%4 != 0 || h_out%3 != 0) || (w_out*3 != h_out*4)))
 	{
 		s360_print("Invalid output resolution for cubemap, suugested aspect "
 			"ratio 4:3 and must be multiple of 4: %dx%d\n", w_out, h_out);


### PR DESCRIPTION
h_out should be dividable by 3, not 4

why the restriction of multiple of 4? i think 2 would make sense because chroma might be subsampled by a factor of 2